### PR TITLE
Improve rate limiting for emoji bot, add de-duping

### DIFF
--- a/example/config.go
+++ b/example/config.go
@@ -1,5 +1,7 @@
 package main
 
+import "github.com/ryho/slack-emoji-bot/util"
+
 // Copy this to the parent directory before filling in!
 // The gitignore will prevent this from being sent to GitHUb
 
@@ -22,16 +24,16 @@ const ownerUserOauthToken = `TODO`
 // People really dislike pictures of some frog.
 // Sometimes you have to keep the peace...
 // Can be specified with or without the colons.
-var skipEmojis = map[string]struct{}{
+var skipEmojis = util.StringSet{
 	"TODO": {},
 }
 
 // Some people prefer not to be pinged to join the channel.
-var muteLDAPs = map[string]struct{}{
+var muteLDAPs = util.StringSet{
 	"TODO": {},
 }
 
 // Some people may not want to be a part of this at all.
-var skipLDAPs = map[string]struct{}{
+var skipLDAPs = util.StringSet{
 	"TODO": {},
 }

--- a/last_week_data.go
+++ b/last_week_data.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ryho/slack-emoji-bot/util"
+
 	"github.com/slack-go/slack"
 )
 
@@ -132,11 +134,11 @@ func getChannel(channelName string) (*slack.Channel, error) {
 // This takes in the copied text of a message from Slack, and prints the top Emoji reactions.
 func printTopEmojisByReactionVote(message *slack.Message, allEmojis *SlackEmojiResponseMessage) error {
 	var emojis []*stringCount
-	uniqueUsers := map[string]struct{}{}
+	uniqueUsers := util.StringSet{}
 	for _, reaction := range message.Reactions {
 		emojis = append(emojis, &stringCount{name: reaction.Name, count: reaction.Count})
 		for _, user := range reaction.Users {
-			uniqueUsers[user] = struct{}{}
+			uniqueUsers[user] = util.SetEntry{}
 		}
 	}
 	sort.Sort(ByCount(emojis))

--- a/literally_1984.go
+++ b/literally_1984.go
@@ -1,22 +1,66 @@
 package main
 
-import "strings"
+import (
+	"sort"
+	"strings"
+
+	"github.com/ryho/slack-emoji-bot/util"
+)
 
 func removeSkippedEmojis(response *SlackEmojiResponseMessage) {
 	// Remove colons. This allows the emojis to be specified as
 	// :emoji_name: or just emoji_name
 	for emoji := range skipEmojis {
 		if emoji[0] == ':' {
-			skipEmojis[strings.ReplaceAll(emoji, ":", "")] = struct{}{}
+			skipEmojis[strings.ReplaceAll(emoji, ":", "")] = util.SetEntry{}
 			delete(skipEmojis, emoji)
 		}
 	}
+	uniqueNames := util.StringSet{}
 
+	sort.Sort(EmojiUploadDateSortBackwards(response.Emoji))
+	var newEmojiList []*emoji
 	for i := 0; i < len(response.Emoji); i++ {
 		emoji := response.Emoji[i]
 		if _, ok := skipEmojis[emoji.Name]; ok {
-			response.Emoji[i] = response.Emoji[len(response.Emoji)-1]
-			response.Emoji = response.Emoji[:len(response.Emoji)-1]
+			delete(response.emojiMap, emoji.Name)
+			continue
+		}
+		if skipScreenShots && strings.HasPrefix(emoji.Name, "screen-shot-") {
+			delete(response.emojiMap, emoji.Name)
+			continue
+		}
+		if skipDuplicateBulkImportEmojis {
+			// If this is turned on, emojis in the format "emoji-name-123" will be skipped.
+			// This is the format used by Slack if another work space's emojis are merged in and there are duplicate names.
+			lastOccurrence := strings.LastIndex(emoji.Name, "-")
+			if lastOccurrence != -1 {
+				ending := emoji.Name[lastOccurrence+1:]
+				if len(ending) > 0 && onlyNumbers(ending) {
+					delete(response.emojiMap, emoji.Name)
+					continue
+				}
+			}
+		}
+		// Do not include emojis if after removing - and _ they are a dupe of an existing emoji.
+		if strictUniqueMode {
+			cleanName := strings.ReplaceAll(strings.ReplaceAll(strings.ToLower(emoji.Name), "-", ""), "_", "")
+			if _, ok := uniqueNames[cleanName]; ok {
+				delete(response.emojiMap, emoji.Name)
+				continue
+			}
+			uniqueNames[cleanName] = util.SetEntry{}
+		}
+		newEmojiList = append(newEmojiList, emoji)
+	}
+	response.Emoji = newEmojiList
+}
+
+func onlyNumbers(input string) bool {
+	for _, character := range input {
+		if !(character >= '0' && character <= '9') {
+			return false
 		}
 	}
+	return true
 }

--- a/main.go
+++ b/main.go
@@ -32,6 +32,14 @@ const (
 
 	findLongestEmojisAllTime = false
 
+	// If this is turned on, emojis in the format "emoji-name-123" will be skipped.
+	// This is the format used by Slack if another work space's emojis are merged in and there are duplicate names.
+	skipDuplicateBulkImportEmojis = true
+	// Do not include emojis if after removing - and _ they are a dupe of an existing emoji.
+	strictUniqueMode = true
+	// Skip emojis that begin with screen-shot-, the format that Mac uses by default.
+	skipScreenShots = true
+
 	// Replaces all emoijs sent with a single emoji, ideally an old school windows broken image emoji.
 	aprilFoolsMode = false
 	// Do not include the colons
@@ -40,6 +48,7 @@ const (
 	// Needs to be used after turning off April Fools mode
 	// to prevent the joke emoji from being detected as the last mew emoji.
 	// Can also be used when running the script for the first time.
+	// Can have colons or not, doesn't matter.
 	overRideLastNewEmoji = ""
 
 	// The channel to post these messages in when in FULL_SEND mode.
@@ -237,6 +246,12 @@ type EmojiUploadDateSort []*emoji
 func (p EmojiUploadDateSort) Len() int           { return len(p) }
 func (p EmojiUploadDateSort) Less(i, j int) bool { return p[i].Created > p[j].Created }
 func (p EmojiUploadDateSort) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+type EmojiUploadDateSortBackwards []*emoji
+
+func (p EmojiUploadDateSortBackwards) Len() int           { return len(p) }
+func (p EmojiUploadDateSortBackwards) Less(i, j int) bool { return p[i].Created < p[j].Created }
+func (p EmojiUploadDateSortBackwards) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
 type ByCount []*stringCount
 

--- a/response_caching.go
+++ b/response_caching.go
@@ -12,6 +12,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/ryho/slack-emoji-bot/util"
 )
 
 const (
@@ -112,9 +114,9 @@ func detectDeletedEmojis(response *SlackEmojiResponseMessage) error {
 	}
 
 	if lastResponseBytes != nil {
-		allCurrentEmojis := make(map[string]struct{})
+		allCurrentEmojis := make(util.StringSet)
 		for _, emoji := range response.Emoji {
-			allCurrentEmojis[emoji.Name] = struct{}{}
+			allCurrentEmojis[emoji.Name] = util.SetEntry{}
 		}
 		lastResponse, err := parseEmojiResponse(lastResponseBytes)
 		if err != nil {

--- a/util/util.go
+++ b/util/util.go
@@ -1,0 +1,5 @@
+package util
+
+type SetEntry struct{}
+
+type StringSet map[string]SetEntry


### PR DESCRIPTION
This will listen to Slack's recommended sleep time when rate limited. It will also get rid of duplicate emojis (emojis that Slack has appended numbers to, emojis that are the same if you remove - or _, and screen shot emojis.)