### PR TITLE
Fast mode

### DIFF
--- a/brings-you-counter.go
+++ b/brings-you-counter.go
@@ -8,14 +8,20 @@ import (
 func bringsYouCounter(response *SlackEmojiResponseMessage) error {
 	var bufoEmojis []string
 	var bringsYouEmojis []string
+
+	lastNewEmojiSanitized := strings.ReplaceAll(lastNewEmoji, ":", "")
 	for _, emoji := range response.Emoji {
+		if fastMode && emoji.Name == lastNewEmojiSanitized {
+			break
+		}
 		if strings.Contains(emoji.Name, "bringsyou") ||
 			strings.Contains(emoji.Name, "brings-you") ||
 			strings.Contains(emoji.Name, "brings_you") ||
 			strings.Contains(emoji.Name, "bringyou") ||
 			strings.Contains(emoji.Name, "bring-you") ||
 			strings.Contains(emoji.Name, "bring_you") ||
-			strings.Contains(emoji.Name, "he-bringin") {
+			strings.Contains(emoji.Name, "he-bringin") ||
+			strings.Contains(emoji.Name, "hbu-") {
 			// increment the counter
 			bringsYouEmojis = append(bringsYouEmojis, emoji.Name)
 		}
@@ -31,9 +37,16 @@ func bringsYouCounter(response *SlackEmojiResponseMessage) error {
 	}
 	randomBufoEmoji := bufoEmojis[rand.Intn(len(bufoEmojis))]
 	randomBringsYouEmoji := bringsYouEmojis[rand.Intn(len(bringsYouEmojis))]
-	_, err := printMessage(MSG_TYPE__SEND_AND_REVIEW,
-		printer.Sprintf("%s There are now %d *he-brings-you* emojis :%s: and %d *Bufo* emojis :%s:!",
-			startEmoji, len(bringsYouEmojis), randomBringsYouEmoji, len(bufoEmojis), randomBufoEmoji))
+	var err error
+	if fastMode {
+		_, err = printMessage(MSG_TYPE__SEND_AND_REVIEW,
+			printer.Sprintf("%s There are %d new *he-brings-you* emojis :%s: and %d new *Bufo* emojis :%s: this week!",
+				startEmoji, len(bringsYouEmojis), randomBringsYouEmoji, len(bufoEmojis), randomBufoEmoji))
+	} else {
+		_, err = printMessage(MSG_TYPE__SEND_AND_REVIEW,
+			printer.Sprintf("%s There are now %d *he-brings-you* emojis :%s: and %d *Bufo* emojis :%s:!",
+				startEmoji, len(bringsYouEmojis), randomBringsYouEmoji, len(bufoEmojis), randomBufoEmoji))
+	}
 
 	return err
 }

--- a/emojis_wrapped.go
+++ b/emojis_wrapped.go
@@ -10,11 +10,11 @@ import (
 
 func emojisWrapped(allEmojis *SlackEmojiResponseMessage) error {
 	// Get the emojis channel
-	emojiChannelData, err := getChannel(emojiChannel)
+	emojiChannelID, err := getChannel(emojiChannel)
 	if err != nil {
 		return err
 	}
-	messages, err := findAllVotePrompts(emojiChannelData)
+	messages, err := findAllVotePrompts(emojiChannelID)
 	if err != nil {
 		return err
 	}
@@ -34,13 +34,13 @@ func emojisWrapped(allEmojis *SlackEmojiResponseMessage) error {
 	return printTopEmojisByReactionVote(allEmojis, true, 100, messages...)
 }
 
-func findAllVotePrompts(emojiChannelData *slack.Channel) ([]*slack.Message, error) {
+func findAllVotePrompts(emojiChannelId string) ([]*slack.Message, error) {
 	conversationParams := &slack.GetConversationHistoryParameters{
-		ChannelID: emojiChannelData.ID,
+		ChannelID: emojiChannelId,
 	}
 	var reactionMessages []*slack.Message
 	for true {
-		messages, err := slackApi.GetConversationHistory(conversationParams)
+		messages, err := GetConversationHistoryWithBackoff(conversationParams)
 		if err != nil {
 			return nil, err
 		}

--- a/people_printing.go
+++ b/people_printing.go
@@ -104,12 +104,12 @@ func printTopPeople(firstMessage, secondMessage string, people map[string]*strin
 		if !ok {
 			return fmt.Errorf("could not find user %v %v", peopleCountArray[i].id, peopleCountArray[i].name)
 		}
-		if _, ok := skipLDAPs[user.Name]; ok {
+		if _, ok := skipLDAPs[user.Profile.DisplayName]; ok {
 			// This skips the user so they do not show up at all.
 			skipCorrection++
 			continue
 		}
-		if _, ok := muteLDAPs[user.Name]; ok {
+		if _, ok := muteLDAPs[user.Profile.DisplayName]; ok {
 			// This prints the LDAP with no @ sign, so they will not be pinged.
 			if i < TopPeopleToPrint {
 				firstMessage += printer.Sprintf("%d. %s (%s) %d\n", i+1-skipCorrection, peopleCountArray[i].name, user.Name, peopleCountArray[i].count)
@@ -170,10 +170,10 @@ func printTopCreators(message string, TopPeopleToPrint int, peopleIds []string, 
 		if !ok {
 			return fmt.Errorf("could not find user %v", peopleId)
 		}
-		if _, ok := skipLDAPs[user.Name]; ok {
+		if _, ok := skipLDAPs[user.Profile.DisplayName]; ok {
 			continue
 		}
-		if _, ok := muteLDAPs[user.Name]; ok {
+		if _, ok := muteLDAPs[user.Profile.DisplayName]; ok {
 			// This prints the LDAP with no @ sign, so they will not be pinged.
 			if i < TopPeopleToPrint {
 				firstMessage += printer.Sprintf("%d. %s (%s) :%s: %d\n", i+1, user.RealName, user.Name, emojis[i], reactions[i])


### PR DESCRIPTION
- Adds a fast mode that only fetches the necessary emojis instead of all emojis.
- Channel ID can now be cached, since looking up the channel ID is slow. If the channel ID has to be fetched, it will be printed and suggest setting it.
- The year for year in review is no longer hard coded and is based on the actual year.
- More of the calls are wrapped with retry and backoff logic.
